### PR TITLE
Refactor API and music handling for improved Spotify integration

### DIFF
--- a/niver2025/api.js
+++ b/niver2025/api.js
@@ -7,8 +7,8 @@ const API_BASE_URL = (() => {
     return "http://localhost:3001"; // Local development
   }
 
-  // In production, use the current origin
-  return window.location.origin;
+  // In production, use Netlify Functions URL
+  return `${window.location.origin}/.netlify/functions/api`;
 })();
 
 console.log("API Service initialized with base URL:", API_BASE_URL);

--- a/niver2025/music.js
+++ b/niver2025/music.js
@@ -44,8 +44,10 @@ function debounce(func, wait) {
 }
 
 // Display search results
-function displaySearchResults(tracks) {
+function displaySearchResults(response) {
   searchResults.innerHTML = "";
+  const tracks = response.tracks || [];
+
   if (tracks.length === 0) {
     searchResults.style.display = "none";
     return;
@@ -55,12 +57,10 @@ function displaySearchResults(tracks) {
     const resultItem = document.createElement("div");
     resultItem.className = "search-result-item";
     resultItem.innerHTML = `
-            <img src="${track.album.images[2]?.url || ""}" alt="${track.name}">
+            <img src="${track.image || ""}" alt="${track.name}">
             <div class="track-info">
                 <div class="track-name">${track.name}</div>
-                <div class="artist-name">${track.artists
-                  .map((artist) => artist.name)
-                  .join(", ")}</div>
+                <div class="artist-name">${track.artist}</div>
             </div>
         `;
 
@@ -83,12 +83,10 @@ function addTrackToSuggestions(track) {
   trackElement.className = "suggested-music-item";
   trackElement.dataset.trackId = track.id;
   trackElement.innerHTML = `
-        <img src="${track.album.images[2]?.url || ""}" alt="${track.name}">
+        <img src="${track.image || ""}" alt="${track.name}">
         <div class="track-info">
             <div class="track-name">${track.name}</div>
-            <div class="artist-name">${track.artists
-              .map((artist) => artist.name)
-              .join(", ")}</div>
+            <div class="artist-name">${track.artist}</div>
         </div>
         <div class="track-status"></div>
         <button class="remove-button" title="Remover música">&times;</button>
@@ -164,8 +162,8 @@ function addTrackToSuggestions(track) {
   // Store complete track data
   trackElement.dataset.trackData = JSON.stringify({
     song_title: track.name,
-    artist: track.artists.map((artist) => artist.name).join(", "),
-    spotify_url: track.external_urls?.spotify || null,
+    artist: track.artist,
+    spotify_url: track.preview_url || null,
   });
 
   // Add track to Spotify playlist with loading state


### PR DESCRIPTION
- Updated API base URL to use Netlify Functions URL for production.
- Refactored `displaySearchResults` and `addTrackToSuggestions` functions in `music.js` to streamline track data handling.
- Enhanced error handling in the Netlify function for Spotify search and added new routes for participant management.
- Improved server-side Spotify search endpoint to include token refresh logic and structured response formatting.
- 
This pull request introduces several changes to improve the Spotify integration, enhance API functionality, and simplify the handling of music track data across the application. Key updates include refining the Spotify search endpoint, adding new API routes for participant management, and modifying the structure of track data for consistency.

### Spotify Integration Improvements:
* Updated the production `API_BASE_URL` in `niver2025/api.js` to use Netlify Functions URL instead of the current origin. This ensures compatibility with serverless architecture.
* Refined Spotify search logic in `niver2025/netlify/functions/api.js` and `niver2025/server/index.js` to include token refresh handling, improved error responses, and consistent formatting of track data. [[1]](diffhunk://#diff-c987dfc0bb79148d5280666cb18a1a9f3b17f03692b7cdf7e8b52116ecff8749L44-R97) [[2]](diffhunk://#diff-e0c3b54830ac1b90b3b2251e5e9979c335b3b6c9f241d83a2f272c7f5680070fL303-L327)

### API Enhancements:
* Added new API routes in `niver2025/netlify/functions/api.js` for managing participants (`/participants`, `/participants/count`). These routes support retrieving, adding, and counting participant data using Supabase.

### Music Track Data Simplification:
* Updated `displaySearchResults` and `addTrackToSuggestions` functions in `niver2025/music.js` to use a simplified track data structure (`image` and `artist` fields) for consistency across the application. [[1]](diffhunk://#diff-cc01a73b34e5783ced53d82c74c178baaf816f1a71dc5cd439a1aa8688a3fa64L47-R50) [[2]](diffhunk://#diff-cc01a73b34e5783ced53d82c74c178baaf816f1a71dc5cd439a1aa8688a3fa64L58-R63) [[3]](diffhunk://#diff-cc01a73b34e5783ced53d82c74c178baaf816f1a71dc5cd439a1aa8688a3fa64L86-R89) [[4]](diffhunk://#diff-cc01a73b34e5783ced53d82c74c178baaf816f1a71dc5cd439a1aa8688a3fa64L167-R166)